### PR TITLE
Switched to build-essential cookbook to support additional operating systems.

### DIFF
--- a/cookbooks/perlbrew/README.md
+++ b/cookbooks/perlbrew/README.md
@@ -4,8 +4,11 @@ Description
 Installs perlbrew and provides resource/provider types for managing
 perls with perlbrew.
 
-To date, this cookbook has only been designed and tested on the
-Ubuntu and Debian platforms.
+To date, this cookbook has been designed and tested on the following platforms:
+* Ubuntu
+* Debian
+* CentOS 6
+* Amazon Linux
 
 Requirements
 ============
@@ -17,7 +20,9 @@ installed if missing)
 
 * curl
 * perl
-* build-essential
+* patch
+
+The ```build-essential``` <https://github.com/opscode-cookbooks/build-essential> cookbook will install the packages required for compiling Perl.
 
 Attributes
 ==========

--- a/cookbooks/perlbrew/metadata.rb
+++ b/cookbooks/perlbrew/metadata.rb
@@ -5,5 +5,9 @@ version          "0.1.0"
 description      "Installs/Configures perlbrew"
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
 recipe           "perlbrew::default", "Installs/updates perlbrew"
-supports         "debian"
-supports         "ubuntu"
+
+%w{ debian ubuntu centos amazon }.each do |os|
+  supports os
+end
+
+depends "build-essential"

--- a/cookbooks/perlbrew/recipes/default.rb
+++ b/cookbooks/perlbrew/recipes/default.rb
@@ -17,9 +17,9 @@
 # limitations under the License.
 #
 
-prereqs = [ "build-essential", "perl", "curl" ]
+include_recipe "build-essential"
 
-prereqs.each do |p|
+%w{ patch perl curl }.each do |p|
   package p
 end
 


### PR DESCRIPTION
Needed to use this cookbook on CentOS and Amazon Linux.  Using build-essential fixed that for me.  

I also had to add `patch` as a required package.  Perlbrew isn't able to compile older Perls without it (https://github.com/gugod/App-perlbrew/issues/214).  It wasn't installed by default on either CentOS or Amazon Linux. 
