### PR TITLE
adding attribute to disable self_upgrade

### DIFF
--- a/cookbooks/perlbrew/README.md
+++ b/cookbooks/perlbrew/README.md
@@ -31,6 +31,7 @@ Attributes
 * `node['perlbrew']['perls'] = []` - An array of perls to install, e.g. `["perl-5.14.2", "perl-5.12.3"]`
 * `node['perlbrew']['install_options'] = ''` - A string of command line options for `perlbrew install`, e.g. `-D usethreads` for building all perls with threads
 * `node['perlbrew']['cpanm_options'] = ''` - A string of command line options for `cpanm`, e.g. `--notest` for installing modules without running tests
+* `node['perlbrew']['self_upgrade'] = true` - Set to false if you don't want perlbrew upgraded to the latest version automatically
 
 Recipes
 =======

--- a/cookbooks/perlbrew/attributes/default.rb
+++ b/cookbooks/perlbrew/attributes/default.rb
@@ -26,4 +26,4 @@ default['perlbrew']['perls'] = []
 # attribute is given
 default['perlbrew']['install_options'] = ''
 default['perlbrew']['cpanm_options'] = ''
-
+default['perlbrew']['self_upgrade'] = true

--- a/cookbooks/perlbrew/metadata.rb
+++ b/cookbooks/perlbrew/metadata.rb
@@ -1,3 +1,4 @@
+name             "perlbrew"
 maintainer       "David Golden"
 maintainer_email "dagolden@cpan.org"
 license          "Apache 2.0"

--- a/cookbooks/perlbrew/recipes/default.rb
+++ b/cookbooks/perlbrew/recipes/default.rb
@@ -29,7 +29,6 @@ perlbrew_bin = "#{perlbrew_root}/bin/perlbrew"
 directory perlbrew_root
 
 # if we have perlbrew, upgrade it
-# XXX is this really a good idea?
 bash "perlbrew self-upgrade" do
   environment ({'PERLBREW_ROOT' => perlbrew_root})
   code <<-EOC
@@ -37,7 +36,7 @@ bash "perlbrew self-upgrade" do
   #{perlbrew_bin} -f install-patchperl
   #{perlbrew_bin} -f install-cpanm
   EOC
-  only_if {::File.exists?(perlbrew_bin)}
+  only_if {::File.exists?(perlbrew_bin) and node['perlbrew']['self_upgrade']}
 end
 
 # if not, install it


### PR DESCRIPTION
I've added a `node['perlbrew']['self_upgrade']` attribute. If set to false, perlbrew self-upgrade will not be run. It defaults to true to keep BC.

I've also added the cookbook name to metadata.rb to make foodcritic happy.
