### PR TITLE
Fixing actions on perlbrew_cpan LWRP

### DIFF
--- a/cookbooks/perlbrew/providers/cpanm.rb
+++ b/cookbooks/perlbrew/providers/cpanm.rb
@@ -36,3 +36,5 @@ action :install do
   p.run_action(:run)
   new_resource.updated_by_last_action(true)
 end
+
+alias_method :action_run, :action_install

--- a/cookbooks/perlbrew/resources/cpanm.rb
+++ b/cookbooks/perlbrew/resources/cpanm.rb
@@ -18,7 +18,7 @@
 # limitations under the License.
 #
 
-actions :install
+actions :install, :run
 default_action :install
 
 attribute :options, :kind_of => String

--- a/cookbooks/perlbrew/resources/cpanm.rb
+++ b/cookbooks/perlbrew/resources/cpanm.rb
@@ -18,13 +18,9 @@
 # limitations under the License.
 #
 
-actions :run
+actions :install
+default_action :install
 
 attribute :options, :kind_of => String
 attribute :perlbrew, :kind_of => String, :required => true
 attribute :modules, :kind_of => Array, :default => []
-
-def initialize(*args)
-  super
-  @action = :install
-end


### PR DESCRIPTION
The perlbrew_cpan resource defined the :run action but the respective provider implemented :install. :install is now the canonical and default action. :run is an alias of :install and will still work the same as before.
